### PR TITLE
Correctif pour utiliser filterText

### DIFF
--- a/src/components/FilterTrackers.js
+++ b/src/components/FilterTrackers.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-const FilterTrackers = ({onTextChange}) => {
+const FilterTrackers = ({onTextChange, initialFilter}) => {
   const handleChange = (event) => {
     onTextChange(event.target.value);
   };
@@ -11,6 +11,7 @@ const FilterTrackers = ({onTextChange}) => {
         <input
           type='text'
           placeholder='Libellé du Tracker'
+          value={initialFilter}
           onChange={handleChange}
         />
       </div>

--- a/src/components/TrackersApp.js
+++ b/src/components/TrackersApp.js
@@ -18,7 +18,10 @@ const TrackersApp = () => {
 
   return (
     <>
-      <FilterTrackers onTextChange={handleTextChange} />
+      <FilterTrackers
+        onTextChange={handleTextChange}
+        initialFilter={filterText}
+      />
       <TrackersTable trackers={allTrackers} />
     </>
   );


### PR DESCRIPTION
Pour supprimer le warning et ainsi régler le problème de déploiement CircleCI on utilise filterText pour initialiser le composant FilterTrackers.